### PR TITLE
Fix results extraction loop

### DIFF
--- a/src/model/optimizer_regional_flex.py
+++ b/src/model/optimizer_regional_flex.py
@@ -1689,8 +1689,7 @@ class RegionalFlexOptimizer:
             if var_key in results['variables']:
                 results['curtailment'][region] = sum(results['variables'][var_key].values())
 
-        
-            return results
+        return results
 
 def run_model(self, time_limit=None, threads=None):
     """Run the optimization model - wrapper for the solve method.


### PR DESCRIPTION
## Summary
- fix indentation for `return results` in `get_results`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f3e76fbac8321b7a6bbb6a755f257